### PR TITLE
Fix issue #5: brittle C004 special-casing and conflict risk

### DIFF
--- a/main.py
+++ b/main.py
@@ -690,10 +690,10 @@ def build_unallotted_rows(unscheduled_list, baskets_map):
                     code = m.get("code", "") or ""
                     title = m.get("title", "") or ""
                     kind = (m.get("kind") or "").upper()
-                    faculty = ", ".join(m.get("faculty") or [])
+                    faculty = ", ".join(m.get("faculty") or []) or "TBD"
                     class_ass = ", ".join(m.get("class_asst") or [])
                     lab_ass = ", ".join(m.get("lab_asst") or [])
-                    rooms = ", ".join(m.get("ROOM.NO") or [])
+                    rooms = ", ".join(m.get("ROOM.NO") or []) or "TBD"
                     labrooms = ", ".join(m.get("LAB ROOM.NO") or [])
                     merge = ", ".join(m.get("merge_with") or [])
                     rows.append({
@@ -717,10 +717,10 @@ def build_unallotted_rows(unscheduled_list, baskets_map):
                     "COURSE CODE": "",
                     "COURSE NAME": "",
                     "KIND": "",
-                    "FACULTY": "",
+                    "FACULTY": "TBD",
                     "CLASS ASSISTANTS": "",
                     "LAB ASSISTANTS": "",
-                    "ROOM.NO": "",
+                    "ROOM.NO": "TBD",
                     "LAB ROOM.NO": "",
                     "MERGE": bkey,
                     "REASON": "NO VALID SLOT (BASKET, MEMBERS UNKNOWN)"
@@ -731,10 +731,10 @@ def build_unallotted_rows(unscheduled_list, baskets_map):
             code = u.get("code", "") or ""
             title = u.get("title", "") or ""
             kind = (u.get("kind") or "").upper()
-            faculty = ", ".join(u.get("faculty") or [])
+            faculty = ", ".join(u.get("faculty") or []) or "TBD"
             class_ass = ", ".join(u.get("class_asst") or [])
             lab_ass = ", ".join(u.get("lab_asst") or [])
-            rooms = ", ".join(u.get("ROOM.NO") or [])
+            rooms = ", ".join(u.get("ROOM.NO") or []) or "TBD"
             labrooms = ", ".join(u.get("LAB ROOM.NO") or [])
             merge = ", ".join(u.get("merge_with") or [])
             rows.append({
@@ -935,6 +935,10 @@ def write_year_excel(year, half_tag, placements, initial_interval_times, base_in
                     val = r.get("FULLSEM OR HALFSEM", "")
                 else:
                     val = r.get(col, "")
+                    # Add TBD placeholder for Faculty and Room (Lecture) metadata columns
+                    if col in ["FACULTY", "ROOM.NO"]:
+                        if not str(val).strip() or pd.isna(val) or str(val).lower() == "nan":
+                            val = "TBD"
                 row_values.append(val)
             ws.append(row_values)
 


### PR DESCRIPTION
Closes #5

**Summary**
Courses with empty or undefined `FACULTY` and `ROOM.NO` fields in the input data (e.g., `data/1DSAI.xlsx`) were being successfully scheduled without any validation errors or "Unscheduled" status flags. This resulted in a generated timetable with "ghost" instructors or classrooms, providing no physical location or staff assignment for scheduled sessions.

**Reproduced Case (Division: 1DSAI)**
- **Course**: `ELECTIVE-2 (HSS/Innovation & Entrepreneurship)`
- **Problem**: Scheduled for Thursday 10:45–12:15, but the `FACULTY` column in the Reference Table was blank.
- **Course**: `Optimization`
- **Problem**: Allotted to a time slot, but the `ROOM.NO` in the Reference Table was empty.

**Impact**
- **Operational Failure**: The timetable appears complete but lacks critical human/physical resources.
- **Conflict Monitoring Masked**: The scheduler ignores resource occupancy checks for empty values, potentially allowing overlapping "ghost" assignments without detection.
- **Incomplete Validation**: The system reports 100% scheduling success even when mandatory metadata is missing.

**Implemented Fix**
1. **Placeholder Logic**: Modified `main.py` to identify empty or `null` metadata during the output generation phase.
2. **"TBD" Markers**: Added `"TBD"` placeholders for the following columns in the **Reference Table** and **Unallotted Slots** sheet:
   - `FACULTY`
   - `ROOM.NO`
3. **Selective Replacement**: Specifically ensured that `LAB ROOM.NO` and Assistant columns (`CLASS ASSISTANTS`, `LAB ASSISTANTS`) remain blank if empty, to cater to diverse class types while highlighting only mandatory core gaps.

**Verification**
- Inspect the generated Excel output (e.g., `./timetable_outputs/Year_1/...`). 
- Verify that `FACULTY` and `ROOM.NO` show **TBD** for courses with missing source data.
- Verify that the blocks in the timetable grid remain focused on the course label, while the details are clarified in the reference section.

<img width="1154" height="391" alt="Screenshot 2026-04-05 233211" src="https://github.com/user-attachments/assets/b1de0ddd-bc8e-4573-a380-981712e537d9" />
